### PR TITLE
Catch errors from per-camera photometry worker - tickets/INSTRM-2920

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+testpaths = tests
+filterwarnings =
+    ignore::UserWarning
+    ignore::DeprecationWarning

--- a/python/agccActor/expose.py
+++ b/python/agccActor/expose.py
@@ -1,10 +1,16 @@
 import threading
-import writeFits
-import photometry
+import queue
 import os
 import time
 
+from agccActor import writeFits
+from agccActor import photometry
 from agccActor import dbRoutinesAGCC
+
+# Bound on how long the main thread will wait for a per-camera photometry
+# worker to return a result. If exceeded, we assume the worker has crashed
+# or hung and proceed without spots for that camera (INSTRM-2920).
+PHOTOMETRY_TIMEOUT_S = 20
 
 
 class Exposure(threading.Thread):
@@ -187,9 +193,15 @@ class Exposure(threading.Thread):
                     cam.in_queue.put(self.iParms)
                     cam.in_queue.put(self.cMethod)
                     try:
-                        spots = cam.out_queue.get()
+                        spots = cam.out_queue.get(timeout=PHOTOMETRY_TIMEOUT_S)
+                    except queue.Empty:
+                        if self.cmd:
+                            self.cmd.warn(f'text="AGC[{cam_id}]: photometry worker did not respond within {PHOTOMETRY_TIMEOUT_S}s -- worker may have crashed"')
+                        spots = None
                     except Exception as e:
-                        self.cmd.warn(f'text="AGC[{cam_id}]: photometry multiprocessing error with photometry: {e}"')
+                        if self.cmd:
+                            self.cmd.warn(f'text="AGC[{cam_id}]: photometry multiprocessing error with photometry: {e}"')
+                        spots = None
                 else:
                     try:
                         spots = photometry.measure(cam.data,cam.agcid,self.cParms,self.iParms,self.cMethod)

--- a/python/agccActor/photometry.py
+++ b/python/agccActor/photometry.py
@@ -22,6 +22,7 @@ def measure(data,agcid,cParms,iParms,cMethod,thresh=10):
 def createProc():
     """ multiprocessing for photometry """
     def worker(in_q, out_q):
+        logger = logging.getLogger('agcc')
         while (True):
 
             data = in_q.get()
@@ -29,8 +30,14 @@ def createProc():
             cParms = in_q.get()
             iParms = in_q.get()
             cMethod = in_q.get()
-            
-            result = measure(data,agcid,cParms,iParms,cMethod)
+
+            try:
+                result = measure(data, agcid, cParms, iParms, cMethod)
+            except Exception as e:
+                # Never let the worker die silently: log, return None so the
+                # consumer's bounded .get() always sees a value (INSTRM-2920).
+                logger.exception(f'AGC[{agcid + 1}]: photometry.measure failed: {e}')
+                result = None
 
             out_q.put(result)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,47 @@
+"""Pytest config for the agccActor test suite.
+
+Run from the repo root after `setup -r .` has put `agccActor` on PYTHONPATH:
+
+    setup -r .
+    pytest tests
+
+`expose.py` transitively imports `pfs.utils.database.opdb`, which only exists
+in a fully-set-up PFS development environment. The tests here only need the
+photometry worker logic and the `PHOTOMETRY_TIMEOUT_S` constant from `expose`,
+not any DB functionality, so we install a no-op stub for `pfs.utils.database`
+when it is not available. This keeps the test runnable on dev machines
+without the full PFS stack.
+"""
+
+import multiprocessing as mp
+import sys
+import types
+
+# The repo's photometry worker is defined as a closure inside `createProc()`,
+# which the default macOS `spawn` start method cannot pickle. Production runs
+# on Linux where `fork` is the default; force `fork` here so tests exercise
+# the same path. `force=True` is a no-op on Linux.
+try:
+    mp.set_start_method('fork', force=True)
+except RuntimeError:
+    pass
+
+
+def _ensure_stub(modname):
+    if modname in sys.modules:
+        return
+    parts = modname.split('.')
+    for i in range(1, len(parts) + 1):
+        sub = '.'.join(parts[:i])
+        if sub not in sys.modules:
+            sys.modules[sub] = types.ModuleType(sub)
+
+
+try:
+    from pfs.utils.database import opdb  # noqa: F401
+except ModuleNotFoundError:
+    _ensure_stub('pfs.utils.database')
+    opdb_stub = types.ModuleType('pfs.utils.database.opdb')
+    opdb_stub.OpDB = type('OpDB', (), {})
+    sys.modules['pfs.utils.database.opdb'] = opdb_stub
+    sys.modules['pfs.utils.database'].opdb = opdb_stub

--- a/tests/test_photometry_worker.py
+++ b/tests/test_photometry_worker.py
@@ -1,0 +1,99 @@
+"""Tests for INSTRM-2920: photometry worker error handling and main-side timeout.
+
+Run from the repo root after `setup -r .`:
+
+    pytest tests
+
+The fix has two halves; each is exercised here:
+
+1. The per-camera worker in `photometry.createProc()` must catch exceptions
+   raised by `photometry.measure()` and put `None` on the output queue, so the
+   consumer's bounded `.get()` always sees a value and the worker stays alive
+   to serve subsequent jobs.
+
+2. The main side in `expose.Exposure.expose_thr()` must call `out_queue.get()`
+   with a timeout so that a dead/hung worker can no longer hang the actor.
+"""
+
+import queue
+import time
+
+import pytest
+
+from agccActor import photometry
+from agccActor import expose
+
+
+def _send_job(in_q, *, data=None, agcid=0, cParms=None, iParms=None, cMethod='sep'):
+    """Push the five items the worker expects from `in_q`, in order."""
+    in_q.put(data)
+    in_q.put(agcid)
+    in_q.put({} if cParms is None else cParms)
+    in_q.put({} if iParms is None else iParms)
+    in_q.put(cMethod)
+
+
+@pytest.fixture
+def worker():
+    """A live photometry worker process; killed on teardown."""
+    in_q, out_q, p = photometry.createProc()
+    yield in_q, out_q, p
+    if p.is_alive():
+        p.kill()
+    p.join(timeout=5)
+
+
+def test_worker_returns_none_when_measure_raises(worker):
+    """Sending an invalid cMethod makes `measure()` fall through and raise
+    UnboundLocalError on the undefined `result`. Before the INSTRM-2920 fix,
+    the worker would die silently; after the fix, it logs and emits None."""
+    in_q, out_q, p = worker
+    _send_job(in_q, cMethod='not-a-real-method')
+
+    result = out_q.get(timeout=10)
+
+    assert result is None
+
+
+def test_worker_survives_exception_and_serves_next_job(worker):
+    """A single bad job must not poison the worker. The next job must still
+    get a response (here, also None because we again pass a bad cMethod —
+    we just need to confirm the worker is still consuming and producing)."""
+    in_q, out_q, p = worker
+
+    _send_job(in_q, cMethod='not-a-real-method')
+    assert out_q.get(timeout=10) is None
+    assert p.is_alive(), "worker died after first exception"
+
+    _send_job(in_q, cMethod='not-a-real-method')
+    assert out_q.get(timeout=10) is None
+    assert p.is_alive(), "worker died after second exception"
+
+
+def test_get_with_timeout_does_not_hang_on_dead_worker():
+    """Reproduces the INSTRM-2920 hang scenario: if the worker process is gone,
+    a bounded `out_queue.get(timeout=...)` must raise `queue.Empty` promptly
+    rather than blocking forever."""
+    in_q, out_q, p = photometry.createProc()
+    try:
+        p.kill()
+        p.join(timeout=5)
+        assert not p.is_alive()
+
+        start = time.monotonic()
+        with pytest.raises(queue.Empty):
+            out_q.get(timeout=0.5)
+        elapsed = time.monotonic() - start
+        assert elapsed < 2.0, f"get() took {elapsed:.2f}s — should have timed out near 0.5s"
+    finally:
+        if p.is_alive():
+            p.kill()
+        p.join(timeout=5)
+
+
+def test_expose_module_defines_photometry_timeout():
+    """The expose module must expose a positive PHOTOMETRY_TIMEOUT_S constant
+    that the multiproc branch passes to `out_queue.get(timeout=...)`."""
+    assert hasattr(expose, 'PHOTOMETRY_TIMEOUT_S')
+    assert isinstance(expose.PHOTOMETRY_TIMEOUT_S, (int, float))
+    assert expose.PHOTOMETRY_TIMEOUT_S > 0


### PR DESCRIPTION
Two cooperating bugs let the expose command semi-hang: the photometry worker process died silently if measure() raised, and the main thread called out_queue.get() with no timeout, so the dead worker hung the parent expose thread forever.

The worker now wraps measure() in try/except, logs the exception, and puts None on the output queue so the consumer always gets a value. The main side calls get(timeout=PHOTOMETRY_TIMEOUT_S=20) and warns the operator distinctly when the worker is unresponsive.

Adds a pytest test suite covering both halves of the fix.