### PR TITLE
Fix unfinished commands on DB errors (INSTRM-2935)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+---
+
+## [Unreleased] — tickets/INSTRM-2935
+
+### Fixed
+
+- **`insertVisit` hangs MHS on DB error** — if `database.writeVisitToDB()` raised an
+  exception the command was never completed (`cmd.finish()` / `cmd.fail()` not called),
+  hanging the MHS command infrastructure. The call is now wrapped in try/except with
+  `cmd.fail()` on error.
+- **`expose` hangs MHS on DB error** — `Exposure.__init__()` calls
+  `database.getNextAgcExposureId()` and `database.writeExposureToDB()` synchronously
+  before the exposure thread starts. If either raised, the exception escaped back into
+  `Camera.expose()` before `Exposure.start()` was called, so the `cmd.finish()` /
+  `cmd.fail()` inside `Exposure.run()` was never reached. The construction and start of
+  `Exposure` in `camera.py` are now wrapped in try/except with `cmd.fail()` on error.
+- **`gen2.updateTelStatus` result ignored in `expose`** — the return value of the
+  `updateTelStatus` gen2 call was discarded. If gen2 was slow or failed, `tel_status` /
+  `env_condition` rows would be absent and `writeExposureToDB` would raise, triggering the
+  hang above. The result is now checked and `cmd.fail()` is called immediately on failure,
+  matching the pattern already used by `getVisit` in `setOrGetVisit()`.
+
+---
+
 ## [2.0.0] — tickets/INSTRM-2928-02
 
 ### Added

--- a/python/agccActor/Commands/AgccCmd.py
+++ b/python/agccActor/Commands/AgccCmd.py
@@ -172,7 +172,11 @@ class AgccCmd(object):
         """
         cmdKeys = cmd.cmd.keywords
         visit = cmdKeys["visit"].values[0]
-        database.writeVisitToDB(visit)
+        try:
+            database.writeVisitToDB(visit)
+        except Exception as e:
+            cmd.fail(f'text="insertVisit DB error for visit={visit}: {e}"')
+            return
         cmd.finish()
 
     def shutterOps(self, cmd) -> None:
@@ -225,8 +229,13 @@ class AgccCmd(object):
         visit = self.setOrGetVisit(cmd)
         self.actor.logger.info(f"Starting exposure of type {expType} for pfs_visit_id={visit}")
 
-        # Ask gen2 updating the telescope status
-        self.actor.cmdr.call(actor="gen2", cmdStr=f"updateTelStatus caller=agcc visit={visit}", timeLim=5.0)
+        # Ask gen2 to update the telescope status; fail fast if it doesn't succeed.
+        ret = self.actor.cmdr.call(
+            actor="gen2", cmdStr=f"updateTelStatus caller=agcc visit={visit}", timeLim=5.0
+        )
+        if ret.didFail:
+            cmd.fail(f'text="updateTelStatus failed for visit={visit}; cannot write exposure record"')
+            return
 
         if "exptime" in cmdKeys:
             expTime = cmdKeys["exptime"].values[0]

--- a/python/agccActor/camera.py
+++ b/python/agccActor/camera.py
@@ -281,21 +281,24 @@ class Camera(object):
             else:
                 dflag = False
 
-            exp_thr = Exposure(
-                active_cams,
-                expTime_ms,
-                dflag,
-                cParms,
-                iParms,
-                pfsVisitId,
-                cMethod,
-                cmd,
-                combined,
-                centroid,
-                threadDelay=threadDelay,
-                tecOFF=tecOFF,
-            )
-            exp_thr.start()
+            try:
+                exp_thr = Exposure(
+                    active_cams,
+                    expTime_ms,
+                    dflag,
+                    cParms,
+                    iParms,
+                    pfsVisitId,
+                    cMethod,
+                    cmd,
+                    combined,
+                    centroid,
+                    threadDelay=threadDelay,
+                    tecOFF=tecOFF,
+                )
+                exp_thr.start()
+            except Exception as e:
+                cmd.fail(f'text="Exposure setup failed: {e}"')
 
     def abort(self, cmd, cams) -> None:
         """Abort the current exposure on the given cameras.

--- a/tests/test_db_routines.py
+++ b/tests/test_db_routines.py
@@ -1,6 +1,5 @@
-import pytest
 import numpy as np
-import pandas as pd
+import pytest
 from agccActor import database
 
 

--- a/tests/test_exposure.py
+++ b/tests/test_exposure.py
@@ -333,6 +333,7 @@ def test_exposure_inline_photometry_finds_spots(cam_set, mock_cmd, mock_opdb, mi
             combined=False,
             centroid=True,
         )
+        # nframe is set by __init__ (via getNextAgcExposureId); mock covers it.
         # Expose the camera so data is loaded into cam.data
         cam_set.cams[0].setExpTime(100)
         cam_set.cams[0].expose()


### PR DESCRIPTION
## Summary

Two code paths leave a tron command permanently unfinished on database errors, hanging the MHS command infrastructure.

## Root Causes

**Issue 1 — `insertVisit`**: if `database.writeVisitToDB()` raises, the exception escapes the handler before `cmd.finish()` is reached.

**Issue 2 — `expose`**: `Exposure.__init__()` calls `getNextAgcExposureId()` and `writeExposureToDB()` synchronously before the exposure thread starts. If either raises, the exception propagates back into `Camera.expose()` before `Exposure.start()` is called, so the `cmd.finish()`/`cmd.fail()` inside `Exposure.run()` is never reached.

A likely trigger is a race: `AgccCmd.expose()` calls `gen2.updateTelStatus` with a 5 s timeout but never checks whether it succeeded. If gen2 is slow, `tel_status`/`env_condition` rows may not be committed by the time `writeExposureToDB` queries them.

## Fix

- **`AgccCmd.insertVisit`**: wrap `writeVisitToDB` in try/except; call `cmd.fail()` on error.
- **`camera.py`**: wrap `Exposure()` construction and `.start()` in try/except that calls `cmd.fail()` on error. `Exposure.__init__()` is unchanged.
- **`AgccCmd.expose`**: check the return value of `gen2.updateTelStatus` and call `cmd.fail()` immediately if it reports failure — preventing the downstream DB error before it occurs. Mirrors the existing pattern used by `getVisit` in `setOrGetVisit()`.