### PR TITLE
Code cleanup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,8 @@ markers = [
 
 [tool.coverage.run]
 source = ["agccActor"]
+concurrency = ["multiprocessing"]
+parallel = true
 omit = [
     "python/agccActor/fli/fake_camera.py",
     "python/agccActor/version.py",

--- a/python/agccActor/Commands/AgccCmd.py
+++ b/python/agccActor/Commands/AgccCmd.py
@@ -25,7 +25,8 @@ class AgccCmd(object):
         actor : object
             The owning :class:`AgccActor` instance.
         """
-        # This lets us access the rest of the actor.
+        self.cmd = None
+        self.visit = None
         self.instrumentalParams = None
         self.centroidingParams = None
         self.actor = actor
@@ -135,6 +136,34 @@ class AgccCmd(object):
         cmd.inform('text="Present!"')
         cmd.finish()
 
+    def lookup_cameras(self, cmd: Command, defaultToRunning: bool = False) -> list[int]:
+        """Parse the ``cameras`` keyword to get a list of 0-indexed camera IDs.
+
+        Parameters
+        ----------
+        cmd : object
+            The parsed tron command object.
+        defaultToRunning : bool, default False
+            If True and the ``cameras`` keyword is missing, default to the
+            currently running cameras. Otherwise, default to all cameras.
+
+        Returns
+        -------
+        list of int
+            A list of 0-indexed camera IDs.
+        """
+        cmdKeys = cmd.cmd.keywords
+        if "cameras" in cmdKeys:
+            camList = cmdKeys["cameras"].values[0]
+            return [int(cam) - 1 for cam in camList]
+
+        if defaultToRunning:
+            cams = self.actor.camera.runningCameras()
+            cmd.inform(f'text="found cameras: {cams}"')
+            return cams
+
+        return list(range(nCams))
+
     def setOrGetVisit(self, cmd: Command) -> int:
         """Return the ``visit`` from the command keys, or fetch one from gen2.
 
@@ -152,8 +181,6 @@ class AgccCmd(object):
         self.cmd = cmd
         cmdKeys = cmd.cmd.keywords
 
-        # When we start a new visit, always reset frame counter.
-        self.frameSeq = 0
         if "visit" in cmdKeys:
             self.visit = cmdKeys["visit"].values[0]
         else:
@@ -194,19 +221,7 @@ class AgccCmd(object):
         """
         cmdKeys = cmd.cmd.keywords
         shutterMode = cmdKeys[0].name
-        cams = []
-        if "cameras" in cmdKeys:
-            camList = cmdKeys["cameras"].values[0]
-            for cam in camList:
-                k = int(cam) - 1
-                if k < 0 or k >= nCams:
-                    cmd.error(f'text="camera list error: {camList}"')
-                    cmd.fail(f'text="camera list error: {camList}"')
-                    return
-                cams.append(k)
-        else:
-            for k in range(nCams):
-                cams.append(k)
+        cams = self.lookup_cameras(cmd)
 
         if shutterMode == "open":
             self.actor.camera.openShutter(cmd, cams)
@@ -251,10 +266,10 @@ class AgccCmd(object):
             if cmdKeys["combined"].values[0] == 0:
                 combined = False
 
-        centroid = False
+        do_centroid = False
         if "centroid" in cmdKeys:
             if cmdKeys["centroid"].values[0] == 1:
-                centroid = True
+                do_centroid = True
 
         cMethod = "sep"
         if "cMethod" in cmdKeys:
@@ -275,25 +290,13 @@ class AgccCmd(object):
 
         self.actor.logger.info(
             f"Setting image params: {visit=} {expTime=} {combined=} "
-            f"{centroid=} {cMethod=} {threadDelay=} {tecOFF=}"
+            f"{do_centroid=} {cMethod=} {threadDelay=} {tecOFF=}"
         )
 
         magFit = self.instrumentalParams["magFit"]
         cmd.inform(f'text="read magFit = {magFit}"')
 
-        cams = []
-        if "cameras" in cmdKeys:
-            camList = cmdKeys["cameras"].values[0]
-            for cam in camList:
-                k = int(cam) - 1
-                if k < 0 or k >= nCams:
-                    cmd.error(f'text="camera list error: {camList}"')
-                    cmd.fail(f'text="camera list error: {camList}"')
-                    return
-                cams.append(k)
-        else:
-            cams = self.actor.camera.runningCameras()
-            cmd.inform(f'text="found cameras: {cams}"')
+        cams = self.lookup_cameras(cmd, defaultToRunning=True)
 
         # Report TEC before taking exposure
         self.actor.camera.reportTEC(cmd)
@@ -304,7 +307,7 @@ class AgccCmd(object):
             expType,
             cams,
             combined,
-            centroid,
+            do_centroid,
             visit,
             self.centroidingParams,
             cMethod,
@@ -322,20 +325,7 @@ class AgccCmd(object):
             The parsed tron command object.
         """
 
-        cmdKeys = cmd.cmd.keywords
-        cams = []
-        if "cameras" in cmdKeys:
-            camList = cmdKeys["cameras"].values[0]
-            for cam in camList:
-                k = int(cam) - 1
-                if k < 0 or k >= nCams:
-                    cmd.error(f'text="camera list error: {camList}"')
-                    cmd.fail(f'text="camera list error: {camList}"')
-                    return
-                cams.append(k)
-        else:
-            for k in range(nCams):
-                cams.append(k)
+        cams = self.lookup_cameras(cmd)
 
         self.actor.camera.abort(cmd, cams)
         cmd.finish('text="Last exposure aborted!"')
@@ -353,19 +343,7 @@ class AgccCmd(object):
         """
 
         cmdKeys = cmd.cmd.keywords
-        cams = []
-        if "cameras" in cmdKeys:
-            camList = cmdKeys["cameras"].values[0]
-            for cam in camList:
-                k = int(cam) - 1
-                if k < 0 or k >= nCams:
-                    cmd.error(f'text="camera list error: {camList}"')
-                    cmd.fail(f'text="camera list error: {camList}"')
-                    return
-                cams.append(k)
-        else:
-            for k in range(nCams):
-                cams.append(k)
+        cams = self.lookup_cameras(cmd)
 
         if "bx" in cmdKeys:
             bx = cmdKeys["bx"].values[0]
@@ -395,20 +373,7 @@ class AgccCmd(object):
             The parsed tron command object.
         """
 
-        cmdKeys = cmd.cmd.keywords
-        cams = []
-        if "cameras" in cmdKeys:
-            camList = cmdKeys["cameras"].values[0]
-            for cam in camList:
-                k = int(cam) - 1
-                if k < 0 or k >= nCams:
-                    cmd.error(f'text="camera list error: {camList}"')
-                    cmd.fail(f'text="camera list error: {camList}"')
-                    return
-                cams.append(k)
-        else:
-            for k in range(nCams):
-                cams.append(k)
+        cams = self.lookup_cameras(cmd)
 
         self.actor.camera.resetframe(cmd, cams)
 
@@ -424,19 +389,7 @@ class AgccCmd(object):
         cmdKeys = cmd.cmd.keywords
         mode = cmdKeys["mode"].values[0]
 
-        cams = []
-        if "cameras" in cmdKeys:
-            camList = cmdKeys["cameras"].values[0]
-            for cam in camList:
-                k = int(cam) - 1
-                if k < 0 or k >= nCams:
-                    cmd.error(f'text="camera list error: {camList}"')
-                    cmd.fail(f'text="camera list error: {camList}"')
-                    return
-                cams.append(k)
-        else:
-            for k in range(nCams):
-                cams.append(k)
+        cams = self.lookup_cameras(cmd)
 
         self.actor.camera.setmode(cmd, mode, cams)
 
@@ -449,20 +402,7 @@ class AgccCmd(object):
             The parsed tron command object.
         """
 
-        cmdKeys = cmd.cmd.keywords
-        cams = []
-        if "cameras" in cmdKeys:
-            camList = cmdKeys["cameras"].values[0]
-            for cam in camList:
-                k = int(cam) - 1
-                if k < 0 or k >= nCams:
-                    cmd.error(f'text="camera list error: {camList}"')
-                    cmd.fail(f'text="camera list error: {camList}"')
-                    return
-                cams.append(k)
-        else:
-            for k in range(nCams):
-                cams.append(k)
+        cams = self.lookup_cameras(cmd)
 
         self.actor.camera.getmode(cmd, cams)
 
@@ -490,11 +430,10 @@ class AgccCmd(object):
         cmdKeys = cmd.cmd.keywords
         temperature = cmdKeys["temperature"].values[0]
         if "cameras" in cmdKeys:
-            camList = cmdKeys["cameras"].values[0]
-            cmd.inform(f'text="Setting temperature for AG cameras = {camList}"')
+            cams = self.lookup_cameras(cmd)
+            cmd.inform(f'text="Setting temperature for AG cameras = {cmdKeys["cameras"].values[0]}"')
 
-            for cam in camList:
-                n = int(cam) - 1
+            for n in cams:
                 cmd.inform(f'text="Setting camera AG{n + 1} to {temperature}"')
                 self.actor.camera.setcamtemperature(cmd, n, temperature)
         else:

--- a/python/agccActor/Commands/AgccCmd.py
+++ b/python/agccActor/Commands/AgccCmd.py
@@ -56,8 +56,8 @@ class AgccCmd(object):
             ("inusesequence", "<sequence>", self.inusesequence),
             ("inusecamera", "<camera>", self.inusecamera),
             ("insertVisit", "<visit>", self.insertVisit),
-            ("setCentroidParams", "[<nmin>] [<thresh>] [<deblend>]", self.setCentroidParams),
-            ("setImageParams", "", self.setImageParams),
+            ("setCentroidParams", "[<nmin>] [<thresh>] [<deblend>]", self.reloadParams),
+            ("setImageParams", "", self.reloadParams),
         ]
 
         # Define typed command arguments for the above commands.
@@ -88,8 +88,8 @@ class AgccCmd(object):
             keys.Key("deblend", types.Float(), help="deblend_cont for sep"),
             keys.Key("cMethod", types.String(), help="method to use for centroiding (win, sep)"),
         )
-        # initialize centroid parameters
-        self.setCentroidParams(None)
+        # initialize centroid and image parameters
+        self.reloadParams(None)
 
     def ping(self, cmd) -> None:
         """Reply to a ``ping`` command to confirm liveness.
@@ -273,7 +273,6 @@ class AgccCmd(object):
             f"Setting image params: {visit=} {expTime=} {combined=} "
             f"{centroid=} {cMethod=} {threadDelay=} {tecOFF=}"
         )
-        self.setImageParams(cmd)
 
         magFit = self.iParms["magFit"]
         cmd.inform(f'text="read magFit = {magFit}"')
@@ -564,8 +563,8 @@ class AgccCmd(object):
         cmd.respond('stat_cam%d="%s"' % (cam_id + 1, stat))
         cmd.finish()
 
-    def setCentroidParams(self, cmd) -> None:
-        """Load centroid parameters from the config file, with keyword overrides.
+    def reloadParams(self, cmd) -> None:
+        """Load centroid and instrumental parameters from the config file.
 
         Parameters
         ----------
@@ -574,20 +573,11 @@ class AgccCmd(object):
             defaults. If ``None``, defaults are loaded without a reply.
         """
 
-        self.cParms = centroid.getCentroidParams(cmd)
-        thresh = self.cParms["thresh"]
-        deblend = self.cParms["deblend"]
-        nmin = self.cParms["nmin"]
+        self.cParms, self.iParms = centroid.getParams(cmd)
         if cmd is not None:
-            cmd.finish(f'text="centroid parameters set thresh/deblend/nmin = {thresh} {deblend} {nmin}"')
-
-    def setImageParams(self, cmd) -> None:
-        """Load per-camera instrumental parameters from the config file.
-
-        Parameters
-        ----------
-        cmd : object or None
-            The parsed tron command object. Currently only used for logging.
-        """
-        self.actor.logger.info(f"Setting image parameters: {cmd=}")
-        self.iParms = centroid.getImageParams(cmd)
+            thresh = self.cParms["thresh"]
+            deblend = self.cParms["deblend"]
+            nmin = self.cParms["nmin"]
+            cmd.finish(
+                f'text="Parameters reloaded. Centroid thresh/deblend/nmin = {thresh}/{deblend}/{nmin}"'
+            )

--- a/python/agccActor/Commands/AgccCmd.py
+++ b/python/agccActor/Commands/AgccCmd.py
@@ -2,8 +2,10 @@
 
 import opscore.protocols.keys as keys
 import opscore.protocols.types as types
+from actorcore.Command import Command
 
 from agccActor import centroid, database
+from agccActor.main import AgccActor
 
 nCams = 6
 
@@ -15,7 +17,7 @@ class AgccCmd(object):
     actor parser, and provides one handler per command.
     """
 
-    def __init__(self, actor):
+    def __init__(self, actor: AgccActor):
         """Register the command vocabulary and keyword dictionary.
 
         Parameters
@@ -91,7 +93,7 @@ class AgccCmd(object):
         # initialize centroid and image parameters
         self.reloadParams(None)
 
-    def ping(self, cmd) -> None:
+    def ping(self, cmd: Command) -> None:
         """Reply to a ``ping`` command to confirm liveness.
 
         Parameters
@@ -103,7 +105,7 @@ class AgccCmd(object):
         cmd.respond("text='I am AG camera actor'")
         cmd.finish()
 
-    def reconnect(self, cmd) -> None:
+    def reconnect(self, cmd: Command) -> None:
         """Reload the camera controller and reconnect the AG cameras.
 
         Parameters
@@ -116,7 +118,7 @@ class AgccCmd(object):
         cmd.inform('text="AG cameras connected!"')
         cmd.finish()
 
-    def status(self, cmd) -> None:
+    def status(self, cmd: Command) -> None:
         """Report the actor version and per-camera status.
 
         Parameters
@@ -131,7 +133,7 @@ class AgccCmd(object):
         cmd.inform('text="Present!"')
         cmd.finish()
 
-    def setOrGetVisit(self, cmd) -> int:
+    def setOrGetVisit(self, cmd: Command) -> int:
         """Return the ``visit`` from the command keys, or fetch one from gen2.
 
         Parameters
@@ -162,7 +164,7 @@ class AgccCmd(object):
 
         return self.visit
 
-    def insertVisit(self, cmd) -> None:
+    def insertVisit(self, cmd: Command) -> None:
         """Insert a row into the ``pfs_visit`` OpDB table.
 
         Parameters
@@ -179,7 +181,7 @@ class AgccCmd(object):
             return
         cmd.finish()
 
-    def shutterOps(self, cmd) -> None:
+    def shutterOps(self, cmd: Command) -> None:
         """Open or close the shutter on the requested cameras.
 
         Parameters
@@ -211,7 +213,7 @@ class AgccCmd(object):
 
         cmd.finish()
 
-    def expose(self, cmd) -> None:
+    def expose(self, cmd: Command) -> None:
         """Take an exposure on the requested cameras.
 
         Recognised command keywords include ``test``/``dark``/``object``,
@@ -309,7 +311,7 @@ class AgccCmd(object):
             tecOFF=tecOFF,
         )
 
-    def abort(self, cmd) -> None:
+    def abort(self, cmd: Command) -> None:
         """Abort the current exposure on the requested cameras.
 
         Parameters
@@ -336,7 +338,7 @@ class AgccCmd(object):
         self.actor.camera.abort(cmd, cams)
         cmd.finish('text="Last exposure aborted!"')
 
-    def setframe(self, cmd) -> None:
+    def setframe(self, cmd: Command) -> None:
         """Set the exposure area on the requested cameras.
 
         Command keywords: ``cameras``, ``bx``, ``by``, ``cx``, ``cy``,
@@ -382,7 +384,7 @@ class AgccCmd(object):
 
         self.actor.camera.setframe(cmd, cams, bx, by, cx, cy, sx, sy)
 
-    def resetframe(self, cmd) -> None:
+    def resetframe(self, cmd: Command) -> None:
         """Reset the exposure area to the full frame on the requested cameras.
 
         Parameters
@@ -408,7 +410,7 @@ class AgccCmd(object):
 
         self.actor.camera.resetframe(cmd, cams)
 
-    def setmode(self, cmd) -> None:
+    def setmode(self, cmd: Command) -> None:
         """Set the readout mode (``0`` = 4 MHz, ``1`` = 500 kHz).
 
         Parameters
@@ -436,7 +438,7 @@ class AgccCmd(object):
 
         self.actor.camera.setmode(cmd, mode, cams)
 
-    def getmode(self, cmd) -> None:
+    def getmode(self, cmd: Command) -> None:
         """Get the current readout mode on the requested cameras.
 
         Parameters
@@ -462,7 +464,7 @@ class AgccCmd(object):
 
         self.actor.camera.getmode(cmd, cams)
 
-    def getmodestring(self, cmd) -> None:
+    def getmodestring(self, cmd: Command) -> None:
         """Get the human-readable readout mode strings from the first camera.
 
         Parameters
@@ -473,7 +475,7 @@ class AgccCmd(object):
 
         self.actor.camera.getmodestring(cmd)
 
-    def settemperature(self, cmd) -> None:
+    def settemperature(self, cmd: Command) -> None:
         """Set the CCD temperature on one or more cameras.
 
         Parameters
@@ -497,7 +499,7 @@ class AgccCmd(object):
             self.actor.camera.settemperature(cmd, temperature)
         cmd.finish('text="Setting camera TEC finished!"')
 
-    def setregions(self, cmd) -> None:
+    def setregions(self, cmd: Command) -> None:
         """Set regions of interest for a given camera.
 
         Parameters
@@ -512,7 +514,7 @@ class AgccCmd(object):
         regions = cmdKeys["regions"].values[0]
         self.actor.camera.setregions(cmd, camid, regions)
 
-    def startsequence(self, cmd) -> None:
+    def startsequence(self, cmd: Command) -> None:
         """Deprecated no-op; the exposure sequence feature has been removed.
 
         Parameters
@@ -523,7 +525,7 @@ class AgccCmd(object):
 
         cmd.finish('text="startsequence is deprecated and no longer supported; command ignored"')
 
-    def stopsequence(self, cmd) -> None:
+    def stopsequence(self, cmd: Command) -> None:
         """Deprecated no-op; the exposure sequence feature has been removed.
 
         Parameters
@@ -534,7 +536,7 @@ class AgccCmd(object):
 
         cmd.finish('text="stopsequence is deprecated and no longer supported; command ignored"')
 
-    def inusesequence(self, cmd) -> None:
+    def inusesequence(self, cmd: Command) -> None:
         """Deprecated no-op; the exposure sequence feature has been removed.
 
         Parameters
@@ -545,7 +547,7 @@ class AgccCmd(object):
 
         cmd.finish('text="inusesequence is deprecated and no longer supported; command ignored"')
 
-    def inusecamera(self, cmd) -> None:
+    def inusecamera(self, cmd: Command) -> None:
         """Report whether a given camera is currently in use.
 
         Parameters
@@ -563,7 +565,7 @@ class AgccCmd(object):
         cmd.respond('stat_cam%d="%s"' % (cam_id + 1, stat))
         cmd.finish()
 
-    def reloadParams(self, cmd) -> None:
+    def reloadParams(self, cmd: Command | None = None) -> None:
         """Load centroid and instrumental parameters from the config file.
 
         Parameters

--- a/python/agccActor/Commands/AgccCmd.py
+++ b/python/agccActor/Commands/AgccCmd.py
@@ -136,14 +136,14 @@ class AgccCmd(object):
         cmd.inform('text="Present!"')
         cmd.finish()
 
-    def lookup_cameras(self, cmd: Command, defaultToRunning: bool = False) -> list[int]:
+    def lookup_cameras(self, cmd: Command, default_to_running: bool = False) -> list[int]:
         """Parse the ``cameras`` keyword to get a list of 0-indexed camera IDs.
 
         Parameters
         ----------
         cmd : object
             The parsed tron command object.
-        defaultToRunning : bool, default False
+        default_to_running : bool, default False
             If True and the ``cameras`` keyword is missing, default to the
             currently running cameras. Otherwise, default to all cameras.
 
@@ -157,7 +157,7 @@ class AgccCmd(object):
             camList = cmdKeys["cameras"].values[0]
             return [int(cam) - 1 for cam in camList]
 
-        if defaultToRunning:
+        if default_to_running:
             cams = self.actor.camera.runningCameras()
             cmd.inform(f'text="found cameras: {cams}"')
             return cams
@@ -296,7 +296,7 @@ class AgccCmd(object):
         magFit = self.instrumentalParams["magFit"]
         cmd.inform(f'text="read magFit = {magFit}"')
 
-        cams = self.lookup_cameras(cmd, defaultToRunning=True)
+        cams = self.lookup_cameras(cmd, default_to_running=True)
 
         # Report TEC before taking exposure
         self.actor.camera.reportTEC(cmd)

--- a/python/agccActor/Commands/AgccCmd.py
+++ b/python/agccActor/Commands/AgccCmd.py
@@ -198,8 +198,8 @@ class AgccCmd(object):
             for cam in camList:
                 k = int(cam) - 1
                 if k < 0 or k >= nCams:
-                    cmd.error('text="camera list error: %s"' % camList)
-                    cmd.fail()
+                    cmd.error(f'text="camera list error: {camList}"')
+                    cmd.fail(f'text="camera list error: {camList}"')
                     return
                 cams.append(k)
         else:
@@ -285,8 +285,8 @@ class AgccCmd(object):
             for cam in camList:
                 k = int(cam) - 1
                 if k < 0 or k >= nCams:
-                    cmd.error('text="camera list error: %s"' % camList)
-                    cmd.fail()
+                    cmd.error(f'text="camera list error: {camList}"')
+                    cmd.fail(f'text="camera list error: {camList}"')
                     return
                 cams.append(k)
         else:
@@ -327,8 +327,8 @@ class AgccCmd(object):
             for cam in camList:
                 k = int(cam) - 1
                 if k < 0 or k >= nCams:
-                    cmd.error('text="camera list error: %s"' % camList)
-                    cmd.fail()
+                    cmd.error(f'text="camera list error: {camList}"')
+                    cmd.fail(f'text="camera list error: {camList}"')
                     return
                 cams.append(k)
         else:
@@ -357,8 +357,8 @@ class AgccCmd(object):
             for cam in camList:
                 k = int(cam) - 1
                 if k < 0 or k >= nCams:
-                    cmd.error('text="camera list error: %s"' % camList)
-                    cmd.fail()
+                    cmd.error(f'text="camera list error: {camList}"')
+                    cmd.fail(f'text="camera list error: {camList}"')
                     return
                 cams.append(k)
         else:
@@ -375,7 +375,7 @@ class AgccCmd(object):
             by = 0
         if "cx" not in cmdKeys or "cy" not in cmdKeys or "sx" not in cmdKeys or "sy" not in cmdKeys:
             cmd.error('text="required parameters (cx,cy,sx,sy) missing"')
-            cmd.fail()
+            cmd.fail('text="required parameters (cx,cy,sx,sy) missing"')
             return
         cx = cmdKeys["cx"].values[0]
         cy = cmdKeys["cy"].values[0]
@@ -400,8 +400,8 @@ class AgccCmd(object):
             for cam in camList:
                 k = int(cam) - 1
                 if k < 0 or k >= nCams:
-                    cmd.error('text="camera list error: %s"' % camList)
-                    cmd.fail()
+                    cmd.error(f'text="camera list error: {camList}"')
+                    cmd.fail(f'text="camera list error: {camList}"')
                     return
                 cams.append(k)
         else:
@@ -428,8 +428,8 @@ class AgccCmd(object):
             for cam in camList:
                 k = int(cam) - 1
                 if k < 0 or k >= nCams:
-                    cmd.error('text="camera list error: %s"' % camList)
-                    cmd.fail()
+                    cmd.error(f'text="camera list error: {camList}"')
+                    cmd.fail(f'text="camera list error: {camList}"')
                     return
                 cams.append(k)
         else:
@@ -454,8 +454,8 @@ class AgccCmd(object):
             for cam in camList:
                 k = int(cam) - 1
                 if k < 0 or k >= nCams:
-                    cmd.error('text="camera list error: %s"' % camList)
-                    cmd.fail()
+                    cmd.error(f'text="camera list error: {camList}"')
+                    cmd.fail(f'text="camera list error: {camList}"')
                     return
                 cams.append(k)
         else:

--- a/python/agccActor/Commands/AgccCmd.py
+++ b/python/agccActor/Commands/AgccCmd.py
@@ -26,6 +26,8 @@ class AgccCmd(object):
             The owning :class:`AgccActor` instance.
         """
         # This lets us access the rest of the actor.
+        self.instrumentalParams = None
+        self.centroidingParams = None
         self.actor = actor
 
         # Declare the commands we implement. When the actor is started
@@ -276,7 +278,7 @@ class AgccCmd(object):
             f"{centroid=} {cMethod=} {threadDelay=} {tecOFF=}"
         )
 
-        magFit = self.iParms["magFit"]
+        magFit = self.instrumentalParams["magFit"]
         cmd.inform(f'text="read magFit = {magFit}"')
 
         cams = []
@@ -304,9 +306,9 @@ class AgccCmd(object):
             combined,
             centroid,
             visit,
-            self.cParms,
+            self.centroidingParams,
             cMethod,
-            self.iParms,
+            self.instrumentalParams,
             threadDelay=threadDelay,
             tecOFF=tecOFF,
         )
@@ -575,11 +577,11 @@ class AgccCmd(object):
             defaults. If ``None``, defaults are loaded without a reply.
         """
 
-        self.cParms, self.iParms = centroid.getParams(cmd)
+        self.centroidingParams, self.instrumentalParams = centroid.getParams(cmd)
         if cmd is not None:
-            thresh = self.cParms["thresh"]
-            deblend = self.cParms["deblend"]
-            nmin = self.cParms["nmin"]
+            thresh = self.centroidingParams["thresh"]
+            deblend = self.centroidingParams["deblend"]
+            nmin = self.centroidingParams["nmin"]
             cmd.finish(
                 f'text="Parameters reloaded. Centroid thresh/deblend/nmin = {thresh}/{deblend}/{nmin}"'
             )

--- a/python/agccActor/camera.py
+++ b/python/agccActor/camera.py
@@ -55,6 +55,7 @@ class Camera(object):
 
         if simulator == 0:
             from agccActor.fli import fli_camera
+
             fli_camera.CameraInit()
 
             # Put available cameras in a dict by serial number.

--- a/python/agccActor/camera.py
+++ b/python/agccActor/camera.py
@@ -111,9 +111,12 @@ class Camera(object):
             if cam is not None:
                 # close the queue as well
                 self.logger.info(f"Closing process ID {cam.proc.pid}.")
-                cam.proc.kill()  # Send stop signal to the input queue
+                cam.in_queue.put("SHUTDOWN")
                 self.logger.info(f"Join the process {cam.proc.pid}.")
-                cam.proc.join()
+                cam.proc.join(timeout=5)
+                if cam.proc.is_alive():
+                    cam.proc.kill()
+                    cam.proc.join()
 
                 cam.close()
                 self.cams[c_i] = None

--- a/python/agccActor/centroid.py
+++ b/python/agccActor/centroid.py
@@ -10,38 +10,45 @@ logger = logging.getLogger("agcc")
 logger.setLevel(logging.INFO)
 
 
-def getCentroidParams(cmd) -> dict:
-    """Read the centroiding parameters from the actor configuration file.
-
-    The defaults from ``$PFS_INSTDATA_DIR/config/actors/agcc.yaml`` are
-    optionally overridden by the ``nmin``, ``thresh`` and ``deblend``
-    keywords present in ``cmd``.
-
-    Parameters
-    ----------
-    cmd : object or None
-        A tron command object whose keywords may override defaults.
-        If ``None`` or lacking keywords, defaults are returned unchanged.
+def getConfig() -> dict:
+    """Read the actor configuration file.
 
     Returns
     -------
     dict
-        Centroiding parameters: thresholds, minimum area, deblending,
-        ellipticity bounds, etc.
+        The full configuration dictionary from ``$PFS_INSTDATA_DIR/config/actors/agcc.yaml``.
     """
+    configPath = os.path.join(os.environ["PFS_INSTDATA_DIR"], "config/actors", "agcc.yaml")
+    with open(configPath, "r") as configFile:
+        return yaml.safe_load(configFile)
+
+
+def getParams(cmd=None) -> tuple[dict, dict]:
+    """Read both centroiding and instrumental parameters from the configuration file.
+
+    Centroiding defaults are optionally overridden by keywords in ``cmd``.
+
+    Parameters
+    ----------
+    cmd : object, optional
+        A tron command object whose keywords (nmin, thresh, deblend) may
+        override centroiding defaults.
+
+    Returns
+    -------
+    centroidParams : dict
+        Centroiding parameters.
+    cameraParams : dict
+        Per-camera instrumental parameters.
+    """
+    config = getConfig()
+    centroidParams = config["agcc"]["centroidParams"]
+    cameraParams = config["agcc"]["cameraParams"]
 
     try:
         commandKeywords = cmd.cmd.keywords
     except AttributeError:
         commandKeywords = []
-
-    configPath = os.path.join(os.environ["PFS_INSTDATA_DIR"], "config/actors", "agcc.yaml")
-
-    with open(configPath, "r") as configFile:
-        defaultConfig = yaml.safe_load(configFile)
-
-    # returns just the values dictionary
-    centroidParams = defaultConfig["agcc"]["centroidParams"]
 
     if "nmin" in commandKeywords:
         centroidParams["nmin"] = int(cmd.cmd.keywords["nmin"].values[0])
@@ -55,29 +62,7 @@ def getCentroidParams(cmd) -> dict:
     centroidParams.setdefault("halfBoxY", 5)
     centroidParams.setdefault("boxSize", 20)
 
-    return centroidParams
-
-
-def getImageParams(cmd) -> dict:
-    """Read the per-camera instrumental parameters from the config file.
-
-    Parameters
-    ----------
-    cmd : object or None
-        A tron command object. Currently unused; accepted for symmetry.
-
-    Returns
-    -------
-    dict
-        Per-camera parameters (regions, bad columns, saturation values,
-        magnitude-fit coefficients, ...).
-    """
-    configPath = os.path.join(os.environ["PFS_INSTDATA_DIR"], "config/actors", "agcc.yaml")
-
-    with open(configPath, "r") as configFile:
-        imageConfig = yaml.safe_load(configFile)
-
-    return imageConfig["agcc"]["cameraParams"]
+    return centroidParams, cameraParams
 
 
 def interpBadCol(data, badCols):

--- a/python/agccActor/centroid.py
+++ b/python/agccActor/centroid.py
@@ -192,6 +192,8 @@ def getCentroidsSep(data, instrumentParams: dict, centroidParams: dict, spotDtyp
     halfBoxY = centroidParams["halfBoxY"]
     boxSize = centroidParams["boxSize"]
 
+    logger.info(f"Running SEP centroiding on AGC camera {agcid + 1} (thresh={thresh}, minarea={minarea})")
+
     # get region information for camera
     region = instrumentParams[str(agcid + 1)]["reg"]
     try:
@@ -205,104 +207,90 @@ def getCentroidsSep(data, instrumentParams: dict, centroidParams: dict, spotDtyp
     processedData = subOverscan(data.astype("float"))
     processedData = interpBadCol(processedData, instrumentParams[str(agcid + 1)]["badCols"])
 
-    regionData1 = processedData[region[2] : region[3], region[0] : region[1]].astype(
-        "float", copy=True, order="C"
-    )
-    regionData2 = processedData[region[6] : region[7], region[4] : region[5]].astype(
-        "float", copy=True, order="C"
-    )
+    # Define bounds for the left and right halves of the detector
+    half_regions = [
+        (region[0], region[1], region[2], region[3]),  # Left half
+        (region[4], region[5], region[6], region[7]),  # Right half
+    ]
 
-    spots1, nSpots1, background1 = do_region_centroiding(regionData1, thresh, minarea, deblend=deblend)
-    spots2, nSpots2, background2 = do_region_centroiding(regionData2, thresh, minarea, deblend=deblend)
+    spots_list = []
+    nSpots_list = []
+    backgrounds = []
 
-    nElem = nSpots1 + nSpots2
+    for side, (x0, x1, y0, y1) in enumerate(half_regions):
+        regionData = processedData[y0:y1, x0:x1].astype("float", copy=True, order="C")
+        spots, nSpots, background = do_region_centroiding(regionData, thresh, minarea, deblend=deblend)
+        spots_list.append(spots)
+        nSpots_list.append(nSpots)
+        backgrounds.append(background)
+        side_name = "left" if side == 0 else "right"
+        logger.info(
+            f"AGC camera {agcid + 1} {side_name} region: detected {nSpots} spots "
+            f"(bg median={np.median(background):.1f}, std={np.std(background):.1f})"
+        )
 
+    nElem = sum(nSpots_list)
+    logger.info(f"AGC camera {agcid + 1}: detected {nElem} spots in total")
     result = np.zeros(nElem, dtype=spotDtype)
 
-    # define the box size for edge detection and moment calculation
-    # boxSize is used for windowedFWHM, halfBox is used for edge flagging.
-    # We keep them separate but defined together for clarity.
+    start_idx = 0
+    for side, (x0, x1, y0, y1) in enumerate(half_regions):
+        spots = spots_list[side]
+        nSpots = nSpots_list[side]
+        background = backgrounds[side]
 
-    # flag spots near edge of region
+        if nSpots == 0:
+            continue
 
-    edgeIndices1 = np.where(
-        np.any(
-            [
-                spots1["x"] - 2 * halfBoxX < 0,
-                spots1["x"] + 2 * halfBoxX > (region[1] - region[0]),
-                spots1["y"] - 2 * halfBoxY < 0,
-                spots1["y"] + 2 * halfBoxY > (region[3] - region[2]),
-            ],
-            axis=0,
+        end_idx = start_idx + nSpots
+        res_slice = result[start_idx:end_idx]
+
+        # flag spots near edge of region
+        edgeIndices = np.where(
+            np.any(
+                [
+                    spots["x"] - 2 * halfBoxX < 0,
+                    spots["x"] + 2 * halfBoxX > (x1 - x0),
+                    spots["y"] - 2 * halfBoxY < 0,
+                    spots["y"] + 2 * halfBoxY > (y1 - y0),
+                ],
+                axis=0,
+            )
         )
-    )
-    ellipticityIndices1 = np.where(
-        np.all(
-            [
-                np.any([spots1["b"] / spots1["a"] < ellip, spots1["b"] / spots1["a"] > 1 / ellip], axis=0),
-                spots1["npix"] < nmin,
-            ],
-            axis=0,
+        ellipticityIndices = np.where(
+            np.all(
+                [
+                    np.any([spots["b"] / spots["a"] < ellip, spots["b"] / spots["a"] > 1 / ellip], axis=0),
+                    spots["npix"] < nmin,
+                ],
+                axis=0,
+            )
         )
-    )
 
-    result["image_moment_00_pix"][0:nSpots1] = spots1["flux"]
-    result["centroid_x_pix"][0:nSpots1] = spots1["x"] + region[0]
-    result["centroid_y_pix"][0:nSpots1] = spots1["y"] + region[2]
-    result["central_image_moment_20_pix"][0:nSpots1] = spots1["x2"]
-    result["central_image_moment_11_pix"][0:nSpots1] = spots1["xy"]
-    result["central_image_moment_02_pix"][0:nSpots1] = spots1["y2"]
-    result["peak_pixel_x_pix"][0:nSpots1] = spots1["xpeak"] + region[0]
-    result["peak_pixel_y_pix"][0:nSpots1] = spots1["ypeak"] + region[2]
-    result["peak_intensity"][0:nSpots1] = spots1["peak"]
-    result["background"][0:nSpots1] = background1[spots1["ypeak"], spots1["xpeak"]]
-    result["flags"][0:nSpots1][edgeIndices1] += SourceDetectionFlag.EDGE
-    result["flags"][0:nSpots1][ellipticityIndices1] += SourceDetectionFlag.BAD_ELLIP
+        res_slice["image_moment_00_pix"] = spots["flux"]
+        res_slice["centroid_x_pix"] = spots["x"] + x0
+        res_slice["centroid_y_pix"] = spots["y"] + y0
+        res_slice["central_image_moment_20_pix"] = spots["x2"]
+        res_slice["central_image_moment_11_pix"] = spots["xy"]
+        res_slice["central_image_moment_02_pix"] = spots["y2"]
+        res_slice["peak_pixel_x_pix"] = spots["xpeak"] + x0
+        res_slice["peak_pixel_y_pix"] = spots["ypeak"] + y0
+        res_slice["peak_intensity"] = spots["peak"]
+        res_slice["background"] = background[spots["ypeak"], spots["xpeak"]]
 
-    # flag spots near edge of region
+        if side == 1:
+            res_slice["flags"] += SourceDetectionFlag.RIGHT
 
-    edgeIndices2 = np.where(
-        np.any(
-            [
-                spots2["x"] - 2 * halfBoxX < 0,
-                spots2["x"] + 2 * halfBoxX > (region[5] - region[4]),
-                spots2["y"] - 2 * halfBoxY < 0,
-                spots2["y"] + 2 * halfBoxY > (region[7] - region[6]),
-            ],
-            axis=0,
-        )
-    )
-    ellipticityIndices2 = np.where(
-        np.all(
-            [
-                np.any([spots2["b"] / spots2["a"] < ellip, spots2["b"] / spots2["a"] > 1 / ellip], axis=0),
-                spots2["npix"] < nmin,
-            ],
-            axis=0,
-        )
-    )
+        res_slice["flags"][edgeIndices] += SourceDetectionFlag.EDGE
+        res_slice["flags"][ellipticityIndices] += SourceDetectionFlag.BAD_ELLIP
 
-    result["image_moment_00_pix"][nSpots1:nElem] = spots2["flux"]
-    result["centroid_x_pix"][nSpots1:nElem] = spots2["x"] + region[4]
-    result["centroid_y_pix"][nSpots1:nElem] = spots2["y"] + region[6]
-    result["central_image_moment_20_pix"][nSpots1:nElem] = spots2["x2"]
-    result["central_image_moment_11_pix"][nSpots1:nElem] = spots2["xy"]
-    result["central_image_moment_02_pix"][nSpots1:nElem] = spots2["y2"]
-    result["peak_pixel_x_pix"][nSpots1:nElem] = spots2["xpeak"] + region[4]
-    result["peak_pixel_y_pix"][nSpots1:nElem] = spots2["ypeak"] + region[6]
-    result["peak_intensity"][nSpots1:nElem] = spots2["peak"]
-    result["background"][nSpots1:nElem] = background2[spots2["ypeak"], spots2["xpeak"]]
-    # set flag for right half of image
-
-    result["flags"][nSpots1:nElem] += SourceDetectionFlag.RIGHT
-
-    result["flags"][nSpots1:nElem][edgeIndices2] += SourceDetectionFlag.EDGE
-    result["flags"][nSpots1:nElem][ellipticityIndices2] += SourceDetectionFlag.BAD_ELLIP
+        start_idx = end_idx
 
     # determine saturation off the unprocessed data
-    satValue = np.zeros((len(result)))
-    satValue[0:nSpots1] = np.repeat(satValue1, nSpots1)
-    satValue[nSpots1:nElem] = np.repeat(satValue2, nSpots2)
+    satValue = np.concatenate([
+        np.repeat(satValue1, nSpots_list[0]),
+        np.repeat(satValue2, nSpots_list[1]),
+    ])
 
     satFlag = data[result["peak_pixel_y_pix"], result["peak_pixel_x_pix"]] >= satValue
 
@@ -335,40 +323,30 @@ def getCentroidsSep(data, instrumentParams: dict, centroidParams: dict, spotDtyp
     # subract the background
 
     tempData = processedData.copy()
-    tempData[region[2] : region[3], region[0] : region[1]] -= background1
-    tempData[region[6] : region[7], region[4] : region[5]] -= background2
+    for side, (x0, x1, y0, y1) in enumerate(half_regions):
+        tempData[y0:y1, x0:x1] -= backgrounds[side]
 
-    m20 = []
-    m02 = []
-    m11 = []
-
-    flags = []
+    non_conv_count = 0
     for i in range(len(result)):
         yPos = result["centroid_x_pix"][i]
         xPos = result["centroid_y_pix"][i]
 
         xv, yv, xyv, conv = windowedFWHM(
-            tempData, yPos, xPos, region, result["flags"][i] & 1, boxSize=boxSize
+            tempData, yPos, xPos, region, result["flags"][i] & SourceDetectionFlag.RIGHT, boxSize=boxSize
         )
 
-        # if the moment didn't converge, revert to the unweighted second moment and set flags
+        # if the moment converged, update values. otherwise keep unweighted ones and add flag.
         if conv == 0:
-            m20.append(xv)
-            m02.append(yv)
-            m11.append(xyv)
+            result["central_image_moment_20_pix"][i] = xv
+            result["central_image_moment_02_pix"][i] = yv
+            result["central_image_moment_11_pix"][i] = xyv
         else:
-            m02.append(result["central_image_moment_02_pix"][i])
-            m20.append(result["central_image_moment_20_pix"][i])
-            m11.append(result["central_image_moment_11_pix"][i])
+            result["flags"][i] += conv
+            non_conv_count += 1
 
-        # add flag for non converged sources
-        flags.append(conv)
+    if non_conv_count > 0:
+        logger.info(f"AGC camera {agcid + 1}: {non_conv_count} spots failed FWHM moment convergence")
 
-    # and update the values
-    result["central_image_moment_20_pix"] = np.array(m20)
-    result["central_image_moment_02_pix"] = np.array(m02)
-    result["central_image_moment_11_pix"] = np.array(m11)
-    result["flags"] = result["flags"] + np.array(flags)
     logger.debug(f"Calculating Magnitude: exptime = {centroidParams['expTime']}")
     result["estimated_magnitude"] = calculateApproximateMagnitude(
         instrumentParams, result["image_moment_00_pix"], centroidParams["expTime"]

--- a/python/agccActor/centroid.py
+++ b/python/agccActor/centroid.py
@@ -115,7 +115,7 @@ def subOverscan(data):
     return data
 
 
-def centroidRegion(data, thresh: float, minarea: int, deblend: float):
+def do_region_centroiding(data, thresh: float, minarea: int, deblend: float):
     """Subtract the background and run SEP source extraction on a region.
 
     Parameters
@@ -212,8 +212,8 @@ def getCentroidsSep(data, instrumentParams: dict, centroidParams: dict, spotDtyp
         "float", copy=True, order="C"
     )
 
-    spots1, nSpots1, background1 = centroidRegion(regionData1, thresh, minarea, deblend=deblend)
-    spots2, nSpots2, background2 = centroidRegion(regionData2, thresh, minarea, deblend=deblend)
+    spots1, nSpots1, background1 = do_region_centroiding(regionData1, thresh, minarea, deblend=deblend)
+    spots2, nSpots2, background2 = do_region_centroiding(regionData2, thresh, minarea, deblend=deblend)
 
     nElem = nSpots1 + nSpots2
 

--- a/python/agccActor/centroid.py
+++ b/python/agccActor/centroid.py
@@ -31,26 +31,31 @@ def getCentroidParams(cmd) -> dict:
     """
 
     try:
-        cmdKeys = cmd.cmd.keywords
+        commandKeywords = cmd.cmd.keywords
     except AttributeError:
-        cmdKeys = []
+        commandKeywords = []
 
-    fileName = os.path.join(os.environ["PFS_INSTDATA_DIR"], "config/actors", "agcc.yaml")
+    configPath = os.path.join(os.environ["PFS_INSTDATA_DIR"], "config/actors", "agcc.yaml")
 
-    with open(fileName, "r") as inFile:
-        defaultParms = yaml.safe_load(inFile)
+    with open(configPath, "r") as configFile:
+        defaultConfig = yaml.safe_load(configFile)
 
     # returns just the values dictionary
-    centParms = defaultParms["agcc"]["centroidParams"]
+    centroidParams = defaultConfig["agcc"]["centroidParams"]
 
-    if "nmin" in cmdKeys:
-        centParms["nmin"] = int(cmd.cmd.keywords["nmin"].values[0])
-    if "thresh" in cmdKeys:
-        centParms["thresh"] = float(cmd.cmd.keywords["thresh"].values[0])
-    if "deblend" in cmdKeys:
-        centParms["deblend"] = float(cmd.cmd.keywords["deblend"].values[0])
+    if "nmin" in commandKeywords:
+        centroidParams["nmin"] = int(cmd.cmd.keywords["nmin"].values[0])
+    if "thresh" in commandKeywords:
+        centroidParams["thresh"] = float(cmd.cmd.keywords["thresh"].values[0])
+    if "deblend" in commandKeywords:
+        centroidParams["deblend"] = float(cmd.cmd.keywords["deblend"].values[0])
 
-    return centParms
+    # add optional box sizes for edge flagging and windowed FWHM
+    centroidParams.setdefault("halfBoxX", 5)
+    centroidParams.setdefault("halfBoxY", 5)
+    centroidParams.setdefault("boxSize", 20)
+
+    return centroidParams
 
 
 def getImageParams(cmd) -> dict:
@@ -67,12 +72,12 @@ def getImageParams(cmd) -> dict:
         Per-camera parameters (regions, bad columns, saturation values,
         magnitude-fit coefficients, ...).
     """
-    fileName = os.path.join(os.environ["PFS_INSTDATA_DIR"], "config/actors", "agcc.yaml")
+    configPath = os.path.join(os.environ["PFS_INSTDATA_DIR"], "config/actors", "agcc.yaml")
 
-    with open(fileName, "r") as inFile:
-        imageParms = yaml.safe_load(inFile)
+    with open(configPath, "r") as configFile:
+        imageConfig = yaml.safe_load(configFile)
 
-    return imageParms["agcc"]["cameraParams"]
+    return imageConfig["agcc"]["cameraParams"]
 
 
 def interpBadCol(data, badCols):
@@ -115,12 +120,12 @@ def subOverscan(data):
 
     h, w = data.shape
     side0 = data[:, : w // 2]
-    side1 = data[:, w // 2:]
+    side1 = data[:, w // 2 :]
     bg0 = np.median(side0[:, :4]).astype(data.dtype)
     bg1 = np.median(side1[:, -4:]).astype(data.dtype)
 
     data[:, : w // 2] -= bg0
-    data[:, w // 2:] -= bg1
+    data[:, w // 2 :] -= bg1
 
     return data
 
@@ -150,10 +155,10 @@ def centroidRegion(data, thresh: float, minarea: int, deblend: float):
     """
 
     # determine the background
-    bgClass = sep.Background(data)
-    background = bgClass.back()
-    rms = bgClass.rms()
-    bgClass.subfrom(data)
+    backgroundEstimation = sep.Background(data)
+    background = backgroundEstimation.back()
+    rms = backgroundEstimation.rms()
+    backgroundEstimation.subfrom(data)
 
     # get spots using sourcing extractor defaults
     spots = sep.extract(data, thresh, rms, minarea=minarea, deblend_cont=deblend)
@@ -162,10 +167,10 @@ def centroidRegion(data, thresh: float, minarea: int, deblend: float):
     return spots, len(spots), background
 
 
-def getCentroidsSep(data, iParms: dict, cParms: dict, spotDtype, agcid: int):
+def getCentroidsSep(data, instrumentParams: dict, centroidParams: dict, spotDtype, agcid: int):
     """Run SEP-based centroiding on an AG camera image.
 
-    Both halves (left and right regions) defined in ``iParms`` are
+    Both halves (left and right regions) defined in ``instrumentParams`` are
     processed independently. Edge, ellipticity, saturation, flat-top and
     non-convergence flags are accumulated, and final windowed second
     moments and estimated magnitudes are filled in.
@@ -174,13 +179,14 @@ def getCentroidsSep(data, iParms: dict, cParms: dict, spotDtype, agcid: int):
     ----------
     data : numpy.ndarray
         2-D raw image from one AG camera.
-    iParms : dict
+    instrumentParams : dict
         Per-camera instrumental parameters; must contain the camera's
         ``reg``, ``badCols``, ``satVal1``/``satVal2`` (optional),
         ``flatVal`` and ``magFit`` entries.
-    cParms : dict
+    centroidParams : dict
         Centroiding parameters: ``thresh``, ``minarea``, ``deblend``,
-        ``ellip``, ``nmin``, ``expTime``.
+        ``ellip``, ``nmin``, ``expTime``, and optional ``halfBoxX``,
+        ``halfBoxY``, ``boxSize``.
     spotDtype : numpy.dtype
         Structured dtype for the output spot record array.
     agcid : int
@@ -192,53 +198,60 @@ def getCentroidsSep(data, iParms: dict, cParms: dict, spotDtype, agcid: int):
         Structured array with one entry per detected spot.
     """
 
-    thresh = cParms["thresh"]
-    minarea = cParms["minarea"]
-    deblend = cParms["deblend"]
-    ellip = cParms["ellip"]
-    nmin = cParms["nmin"]
+    thresh = centroidParams["thresh"]
+    minarea = centroidParams["minarea"]
+    deblend = centroidParams["deblend"]
+    ellip = centroidParams["ellip"]
+    nmin = centroidParams["nmin"]
+    halfBoxX = centroidParams["halfBoxX"]
+    halfBoxY = centroidParams["halfBoxY"]
+    boxSize = centroidParams["boxSize"]
 
     # get region information for camera
-    region = iParms[str(agcid + 1)]["reg"]
+    region = instrumentParams[str(agcid + 1)]["reg"]
     try:
-        satValue1 = iParms[str(agcid + 1)]["satVal1"]
-        satValue2 = iParms[str(agcid + 1)]["satVal2"]
+        satValue1 = instrumentParams[str(agcid + 1)]["satVal1"]
+        satValue2 = instrumentParams[str(agcid + 1)]["satVal2"]
     except (KeyError, IndexError):
-        satValue1 = (2 ** 16) - 1
-        satValue2 = (2 ** 16) - 1
-    flatVal = iParms["flatVal"]
+        satValue1 = (2**16) - 1
+        satValue2 = (2**16) - 1
+    flatVal = instrumentParams["flatVal"]
 
-    dataProc = subOverscan(data.astype("float"))
-    dataProc = interpBadCol(dataProc, iParms[str(agcid + 1)]["badCols"])
+    processedData = subOverscan(data.astype("float"))
+    processedData = interpBadCol(processedData, instrumentParams[str(agcid + 1)]["badCols"])
 
-    _data1 = dataProc[region[2]: region[3], region[0]: region[1]].astype("float", copy=True, order="C")
-    _data2 = dataProc[region[6]: region[7], region[4]: region[5]].astype("float", copy=True, order="C")
+    regionData1 = processedData[region[2] : region[3], region[0] : region[1]].astype(
+        "float", copy=True, order="C"
+    )
+    regionData2 = processedData[region[6] : region[7], region[4] : region[5]].astype(
+        "float", copy=True, order="C"
+    )
 
-    spots1, nSpots1, background1 = centroidRegion(_data1, thresh, minarea, deblend=deblend)
-    spots2, nSpots2, background2 = centroidRegion(_data2, thresh, minarea, deblend=deblend)
+    spots1, nSpots1, background1 = centroidRegion(regionData1, thresh, minarea, deblend=deblend)
+    spots2, nSpots2, background2 = centroidRegion(regionData2, thresh, minarea, deblend=deblend)
 
     nElem = nSpots1 + nSpots2
 
     result = np.zeros(nElem, dtype=spotDtype)
 
+    # define the box size for edge detection and moment calculation
+    # boxSize is used for windowedFWHM, halfBox is used for edge flagging.
+    # We keep them separate but defined together for clarity.
+
     # flag spots near edge of region
 
-    # dynamic fwhm calculation is overenthusiastic with out of focus images
-    fx = 5
-    fy = 5
-
-    ind1 = np.where(
+    edgeIndices1 = np.where(
         np.any(
             [
-                spots1["x"] - 2 * fx < 0,
-                spots1["x"] + 2 * fx > (region[1] - region[0]),
-                spots1["y"] - 2 * fy < 0,
-                spots1["y"] + 2 * fy > (region[3] - region[2]),
+                spots1["x"] - 2 * halfBoxX < 0,
+                spots1["x"] + 2 * halfBoxX > (region[1] - region[0]),
+                spots1["y"] - 2 * halfBoxY < 0,
+                spots1["y"] + 2 * halfBoxY > (region[3] - region[2]),
             ],
             axis=0,
         )
     )
-    ind2 = np.where(
+    ellipticityIndices1 = np.where(
         np.all(
             [
                 np.any([spots1["b"] / spots1["a"] < ellip, spots1["b"] / spots1["a"] > 1 / ellip], axis=0),
@@ -258,25 +271,23 @@ def getCentroidsSep(data, iParms: dict, cParms: dict, spotDtype, agcid: int):
     result["peak_pixel_y_pix"][0:nSpots1] = spots1["ypeak"] + region[2]
     result["peak_intensity"][0:nSpots1] = spots1["peak"]
     result["background"][0:nSpots1] = background1[spots1["ypeak"], spots1["xpeak"]]
-    result["flags"][0:nSpots1][ind1] += SourceDetectionFlag.EDGE
-    result["flags"][0:nSpots1][ind2] += SourceDetectionFlag.BAD_ELLIP
+    result["flags"][0:nSpots1][edgeIndices1] += SourceDetectionFlag.EDGE
+    result["flags"][0:nSpots1][ellipticityIndices1] += SourceDetectionFlag.BAD_ELLIP
 
     # flag spots near edge of region
-    fx = 5
-    fy = 5
 
-    ind1 = np.where(
+    edgeIndices2 = np.where(
         np.any(
             [
-                spots2["x"] - 2 * fx < 0,
-                spots2["x"] + 2 * fx > (region[5] - region[4]),
-                spots2["y"] - 2 * fy < 0,
-                spots2["y"] + 2 * fy > (region[7] - region[6]),
+                spots2["x"] - 2 * halfBoxX < 0,
+                spots2["x"] + 2 * halfBoxX > (region[5] - region[4]),
+                spots2["y"] - 2 * halfBoxY < 0,
+                spots2["y"] + 2 * halfBoxY > (region[7] - region[6]),
             ],
             axis=0,
         )
     )
-    ind2 = np.where(
+    ellipticityIndices2 = np.where(
         np.all(
             [
                 np.any([spots2["b"] / spots2["a"] < ellip, spots2["b"] / spots2["a"] > 1 / ellip], axis=0),
@@ -300,8 +311,8 @@ def getCentroidsSep(data, iParms: dict, cParms: dict, spotDtype, agcid: int):
 
     result["flags"][nSpots1:nElem] += SourceDetectionFlag.RIGHT
 
-    result["flags"][nSpots1:nElem][ind1] += SourceDetectionFlag.EDGE
-    result["flags"][nSpots1:nElem][ind2] += SourceDetectionFlag.BAD_ELLIP
+    result["flags"][nSpots1:nElem][edgeIndices2] += SourceDetectionFlag.EDGE
+    result["flags"][nSpots1:nElem][ellipticityIndices2] += SourceDetectionFlag.BAD_ELLIP
 
     # determine saturation off the unprocessed data
     satValue = np.zeros((len(result)))
@@ -338,20 +349,22 @@ def getCentroidsSep(data, iParms: dict, cParms: dict, spotDtype, agcid: int):
 
     # subract the background
 
-    newData = dataProc.copy()
-    newData[region[2]: region[3], region[0]: region[1]] -= background1
-    newData[region[6]: region[7], region[4]: region[5]] -= background2
+    tempData = processedData.copy()
+    tempData[region[2] : region[3], region[0] : region[1]] -= background1
+    tempData[region[6] : region[7], region[4] : region[5]] -= background2
 
     m20 = []
     m02 = []
     m11 = []
 
     flags = []
-    for ii in range(len(result)):
-        yPos = result["centroid_x_pix"][ii]
-        xPos = result["centroid_y_pix"][ii]
+    for i in range(len(result)):
+        yPos = result["centroid_x_pix"][i]
+        xPos = result["centroid_y_pix"][i]
 
-        xv, yv, xyv, conv = windowedFWHM(newData, yPos, xPos, region, result["flags"][ii] & 1)
+        xv, yv, xyv, conv = windowedFWHM(
+            tempData, yPos, xPos, region, result["flags"][i] & 1, boxSize=boxSize
+        )
 
         # if the moment didn't converge, revert to the unweighted second moment and set flags
         if conv == 0:
@@ -359,9 +372,9 @@ def getCentroidsSep(data, iParms: dict, cParms: dict, spotDtype, agcid: int):
             m02.append(yv)
             m11.append(xyv)
         else:
-            m02.append(result["central_image_moment_02_pix"][ii])
-            m20.append(result["central_image_moment_20_pix"][ii])
-            m11.append(result["central_image_moment_11_pix"][ii])
+            m02.append(result["central_image_moment_02_pix"][i])
+            m20.append(result["central_image_moment_20_pix"][i])
+            m11.append(result["central_image_moment_11_pix"][i])
 
         # add flag for non converged sources
         flags.append(conv)
@@ -371,15 +384,15 @@ def getCentroidsSep(data, iParms: dict, cParms: dict, spotDtype, agcid: int):
     result["central_image_moment_02_pix"] = np.array(m02)
     result["central_image_moment_11_pix"] = np.array(m11)
     result["flags"] = result["flags"] + np.array(flags)
-    logger.debug(f"Calculating Magnitude: exptime = {cParms['expTime']}")
+    logger.debug(f"Calculating Magnitude: exptime = {centroidParams['expTime']}")
     result["estimated_magnitude"] = calculateApproximateMagnitude(
-        iParms, result["image_moment_00_pix"], cParms["expTime"]
+        instrumentParams, result["image_moment_00_pix"], centroidParams["expTime"]
     )
 
     return result
 
 
-def windowedFWHM(data, xPos: float, yPos: float, region, side: int):
+def windowedFWHM(data, xPos: float, yPos: float, region, side: int, boxSize: int = 20):
     """Compute iteratively-weighted second moments around a position.
 
     If the point is near the edge of the region the sub-image is cropped
@@ -399,126 +412,133 @@ def windowedFWHM(data, xPos: float, yPos: float, region, side: int):
         left (``side=0``) and right (``side=1``) halves.
     side : int
         ``0`` for the left region, ``1`` for the right region.
+    boxSize : int, optional
+        Half-size of the box used for the windowed fit.
 
     Returns
     -------
-    sx, sy, sxy : float
+    momentX, momentY, momentXY : float
         Weighted second moments (xx, yy, xy).
     flag : int
         ``0`` on convergence, ``SourceDetectionFlag.BAD_SHAPE`` otherwise.
     """
 
-    maxIt = 30
-    boxSize = 20
+    maxIterations = 30
 
     # initial values
-    sx = 6
-    sy = 6
-    sxy = 0
+    momentX = 6
+    momentY = 6
+    momentXY = 0
 
     w11 = -1
     w12 = -1
     w22 = -1
 
     # some variables for iteration
-    e1_old = 1e6
-    e2_old = 1e6
-    sx_o = 1e6
-    sy_o = 1e6
-    tol1 = 0.001
-    tol2 = 0.01
+    e1Old = 1e6
+    e2Old = 1e6
+    momentXOld = 1e6
+    momentYOld = 1e6
+    tolerance1 = 0.001
+    tolerance2 = 0.01
 
     # determine the sub-image region
-    dMinX1 = int(np.round(xPos - boxSize))
-    dMaxX1 = int(np.round(xPos + boxSize + 1))
-    dMinY1 = int(np.round(yPos - boxSize))
-    dMaxY1 = int(np.round(yPos + boxSize + 1))
+    minXInitial = int(np.round(xPos - boxSize))
+    maxXInitial = int(np.round(xPos + boxSize + 1))
+    minYInitial = int(np.round(yPos - boxSize))
+    maxYInitial = int(np.round(yPos + boxSize + 1))
 
     # check for edges of the region, and adjust accordingly. This includes the central
     # part of the full image
     if side == 0:
         # check for edges of image
-        dMinX = np.max([dMinX1, region[0]])
-        dMinY = np.max([dMinY1, region[2]])
-        dMaxX = np.min([dMaxX1, region[1]])
-        dMaxY = np.min([dMaxY1, region[3]])
+        minX = np.max([minXInitial, region[0]])
+        minY = np.max([minYInitial, region[2]])
+        maxX = np.min([maxXInitial, region[1]])
+        maxY = np.min([maxYInitial, region[3]])
     elif side == 1:
         # check for edges of image
-        dMinX = np.max([dMinX1, region[4]])
-        dMinY = np.max([dMinY1, region[6]])
-        dMaxX = np.min([dMaxX1, region[5]])
-        dMaxY = np.min([dMaxY1, region[7]])
+        minX = np.max([minXInitial, region[4]])
+        minY = np.max([minYInitial, region[6]])
+        maxX = np.min([maxXInitial, region[5]])
+        maxY = np.min([maxYInitial, region[7]])
 
     # and the sub-image
-    winVal = data[dMinY:dMaxY, dMinX:dMaxX]
+    subImage = data[minY:maxY, minX:maxX]
 
     # scale the coordinates by the central position, to avoid numeric overflow
 
-    xVal = np.arange(dMinX, dMaxX) - xPos
-    yVal = np.arange(dMinY, dMaxY) - yPos
+    xVal = np.arange(minX, maxX) - xPos
+    yVal = np.arange(minY, maxY) - yPos
     xv, yv = np.meshgrid(xVal, yVal)
 
     # now the iteration
-    for i in range(0, maxIt):
+    for i in range(0, maxIterations):
         # get the weighting function based on the current values
         # of the moments
 
-        detw = sx * sy - sxy ** 2
-        w11 = sy / detw
-        w12 = -sxy / detw
-        w22 = sx / detw
+        detw = momentX * momentY - momentXY**2
+        w11 = momentY / detw
+        w12 = -momentXY / detw
+        w22 = momentX / detw
 
         r2 = xv * xv * w11 + yv * yv * w22 + 2 * w12 * xv * yv
         w = np.exp(-r2 / 2)
 
         # and calcualte the weighted moments
-        sxow = (winVal * w * (xv) ** 2).sum() / (winVal * w).sum()
-        syow = (winVal * w * (yv) ** 2).sum() / (winVal * w).sum()
-        sxyow = (winVal * w * xv * yv).sum() / (winVal * w).sum()
+        momentXWeighted = (subImage * w * (xv) ** 2).sum() / (subImage * w).sum()
+        momentYWeighted = (subImage * w * (yv) ** 2).sum() / (subImage * w).sum()
+        momentXYWeighted = (subImage * w * xv * yv).sum() / (subImage * w).sum()
         # variables to test for convergence
-        d = sxow + syow
-        e1 = (sxow - syow) / d
-        e2 = 2 * sxyow / d
+        d = momentXWeighted + momentYWeighted
+        e1 = (momentXWeighted - momentYWeighted) / d
+        e2 = 2 * momentXYWeighted / d
 
         # check for convergence
-        if np.all([np.abs(e1 - e1_old) < tol1, np.abs(e2 - e2_old) < tol1,
-                   np.abs(sx / sx_o - 1) < tol2, np.abs(sy / sy_o - 1) < tol2]):
-            if np.any([sxow <= 0, syow <= 0]):
-                return weightedMoment(winVal, xv, yv, w11, w12, w22)
+        if np.all(
+            [
+                np.abs(e1 - e1Old) < tolerance1,
+                np.abs(e2 - e2Old) < tolerance1,
+                np.abs(momentX / momentXOld - 1) < tolerance2,
+                np.abs(momentY / momentYOld - 1) < tolerance2,
+            ]
+        ):
+            if np.any([momentXWeighted <= 0, momentYWeighted <= 0]):
+                return weightedMoment(subImage, xv, yv, w11, w12, w22)
             else:
-                return sxow, syow, sxyow, 0
+                return momentXWeighted, momentYWeighted, momentXYWeighted, 0
 
         # calculate new values
-        e1_old = e1
-        e2_old = e2
-        sx_o = sx
-        sy_o = sy
+        e1Old = e1
+        e2Old = e2
+        momentXOld = momentX
+        momentYOld = momentY
 
-        detow = sxow * syow - sxyow ** 2
-        ow11 = syow / detow
-        ow12 = -sxyow / detow
-        ow22 = sxow / detow
-        if detow <= 0:
-            return weightedMoment(winVal, xv, yv, w11, w12, w22)
+        detWeighted = momentXWeighted * momentYWeighted - momentXYWeighted**2
+        ow11 = momentYWeighted / detWeighted
+        ow12 = -momentXYWeighted / detWeighted
+        ow22 = momentXWeighted / detWeighted
+        if detWeighted <= 0:
+            return weightedMoment(subImage, xv, yv, w11, w12, w22)
 
         n11 = ow11 - w11
         n12 = ow12 - w12
         n22 = ow22 - w22
         det_n = n11 * n22 - n12 * n12
         if det_n <= 0:
-            return weightedMoment(winVal, xv, yv, w11, w12, w22)
+            return weightedMoment(subImage, xv, yv, w11, w12, w22)
 
-        sx = n22 / det_n
-        sxy = -n12 / det_n
-        sy = n11 / det_n
-        if np.any([sx <= 0, sy <= 0]):
-            return weightedMoment(winVal, xv, yv, w11, w12, w22)
+        momentX = n22 / det_n
+        momentXY = -n12 / det_n
+        momentY = n11 / det_n
+        if np.any([momentX <= 0, momentY <= 0]):
+            return weightedMoment(subImage, xv, yv, w11, w12, w22)
 
     # if we haven't converged return new values
-    return sx, sy, sxy, SourceDetectionFlag.BAD_SHAPE
+    return momentX, momentY, momentXY, SourceDetectionFlag.BAD_SHAPE
 
 
-def weightedMoment(winVal, xv, yv, w11: float, w12: float, w22: float):
+def weightedMoment(subImage, xv, yv, w11: float, w12: float, w22: float):
     """Compute a single-pass weighted moment as a fallback.
 
     Used by :func:`windowedFWHM` when the iterative fit fails to converge
@@ -526,7 +546,7 @@ def weightedMoment(winVal, xv, yv, w11: float, w12: float, w22: float):
 
     Parameters
     ----------
-    winVal : numpy.ndarray
+    subImage : numpy.ndarray
         2-D sub-image (background-subtracted) around the source.
     xv, yv : numpy.ndarray
         Coordinate meshgrids relative to the centroid.
@@ -535,7 +555,7 @@ def weightedMoment(winVal, xv, yv, w11: float, w12: float, w22: float):
 
     Returns
     -------
-    sx, sy, sxy : float
+    momentX, momentY, momentXY : float
         Weighted second moments.
     flag : int
         Always ``SourceDetectionFlag.BAD_SHAPE``.
@@ -544,22 +564,22 @@ def weightedMoment(winVal, xv, yv, w11: float, w12: float, w22: float):
     r2 = xv * xv * w11 + yv * yv * w22 + 2 * w12 * xv * yv
     w = np.exp(-r2 / 2)
 
-    sx = (winVal * w * (xv) ** 2).sum() / (winVal * w).sum()
-    sy = (winVal * w * (yv) ** 2).sum() / (winVal * w).sum()
-    sxy = (winVal * w * xv * yv).sum() / (winVal * w).sum()
+    momentX = (subImage * w * (xv) ** 2).sum() / (subImage * w).sum()
+    momentY = (subImage * w * (yv) ** 2).sum() / (subImage * w).sum()
+    momentXY = (subImage * w * xv * yv).sum() / (subImage * w).sum()
 
-    return sx, sy, sxy, SourceDetectionFlag.BAD_SHAPE
+    return momentX, momentY, momentXY, SourceDetectionFlag.BAD_SHAPE
 
 
-def calculateApproximateMagnitude(iParms: dict, instrumentFlux, expTime: float):
+def calculateApproximateMagnitude(instrumentParams: dict, instrumentFlux, expTime: float):
     """Estimate an approximate Gaia magnitude from instrumental flux.
 
     Uses the linear ``magFit = (slope, offset)`` coefficients stored in
-    ``iParms`` applied to ``-2.5 * log10(flux / expTime)``.
+    ``instrumentParams`` applied to ``-2.5 * log10(flux / expTime)``.
 
     Parameters
     ----------
-    iParms : dict
+    instrumentParams : dict
         Instrumental parameters; must contain a ``magFit`` ``(slope, offset)``
         pair.
     instrumentFlux : numpy.ndarray or float
@@ -573,6 +593,9 @@ def calculateApproximateMagnitude(iParms: dict, instrumentFlux, expTime: float):
         Estimated Gaia-like magnitude.
     """
 
-    mag = -2.5 * np.log10(instrumentFlux / expTime) * iParms["magFit"][0] + iParms["magFit"][1]
+    mag = (
+        -2.5 * np.log10(instrumentFlux / expTime) * instrumentParams["magFit"][0]
+        + instrumentParams["magFit"][1]
+    )
 
     return mag

--- a/python/agccActor/centroid.py
+++ b/python/agccActor/centroid.py
@@ -287,10 +287,12 @@ def getCentroidsSep(data, instrumentParams: dict, centroidParams: dict, spotDtyp
         start_idx = end_idx
 
     # determine saturation off the unprocessed data
-    satValue = np.concatenate([
-        np.repeat(satValue1, nSpots_list[0]),
-        np.repeat(satValue2, nSpots_list[1]),
-    ])
+    satValue = np.concatenate(
+        [
+            np.repeat(satValue1, nSpots_list[0]),
+            np.repeat(satValue2, nSpots_list[1]),
+        ]
+    )
 
     satFlag = data[result["peak_pixel_y_pix"], result["peak_pixel_x_pix"]] >= satValue
 

--- a/python/agccActor/photometry.py
+++ b/python/agccActor/photometry.py
@@ -79,6 +79,8 @@ def createProc():
         logger = logging.getLogger("agcc")
         while True:
             data = in_q.get()
+            if isinstance(data, str) and data == "SHUTDOWN":
+                break
             agcid = in_q.get()
             cParms = in_q.get()
             iParms = in_q.get()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,7 +123,7 @@ def mock_cmd():
     cmd = MagicMock()
     for method in ("inform", "warn", "fail", "finish", "respond", "debug"):
         setattr(cmd, method, MagicMock())
-    # centroid.getCentroidParams accesses cmd.cmd.keywords
+    # centroid.getParams accesses cmd.cmd.keywords
     cmd.cmd.keywords = []
     return cmd
 
@@ -180,4 +180,3 @@ def pfs_instdata():
     if not val:
         pytest.skip("PFS_INSTDATA_DIR is not set")
     return Path(val)
-

--- a/tests/test_centroid_replay.py
+++ b/tests/test_centroid_replay.py
@@ -52,8 +52,7 @@ def _skip_if_missing():
 def real_params():
     """Load centroiding and image parameters once for the whole module."""
     _skip_if_missing()
-    cParms = centroid.getCentroidParams(None)
-    iParms = centroid.getImageParams(None)
+    cParms, iParms = centroid.getParams(None)
     return cParms, iParms
 
 

--- a/tests/test_exposure.py
+++ b/tests/test_exposure.py
@@ -36,6 +36,9 @@ def minimal_cParms():
         "ellip": 0.5,
         "nmin": 5,
         "expTime": 0.1,
+        "halfBoxX": 5,
+        "halfBoxY": 5,
+        "boxSize": 20,
     }
 
 
@@ -342,5 +345,3 @@ def test_exposure_inline_photometry_finds_spots(cam_set, mock_cmd, mock_opdb, mi
 
     # Spots found or not — the call must complete without exception
     assert cam_set.cams[0].spots is not None, "spots should be set after inline photometry"
-
-

--- a/tests/test_photometry_worker.py
+++ b/tests/test_photometry_worker.py
@@ -36,20 +36,22 @@ def _send_job(in_q, *, data=None, agcid=0, cParms=None, iParms=None, cMethod='se
 
 @pytest.fixture
 def worker():
-    """A live photometry worker process; killed on teardown."""
+    """A live photometry worker process; terminated gracefully on teardown."""
     in_q, out_q, p = photometry.createProc()
     yield in_q, out_q, p
     if p.is_alive():
-        p.kill()
-    p.join(timeout=5)
+        in_q.put("SHUTDOWN")
+        p.join(timeout=5)
+        if p.is_alive():
+            p.kill()
+            p.join(timeout=2)
 
 
 def test_worker_returns_none_when_measure_raises(worker):
-    """Sending an invalid cMethod makes `measure()` fall through and raise
-    UnboundLocalError on the undefined `result`. Before the INSTRM-2920 fix,
-    the worker would die silently; after the fix, it logs and emits None."""
+    """Sending None data makes `measure()` raise an exception.
+    The worker must catch this, log it, and emit None."""
     in_q, out_q, p = worker
-    _send_job(in_q, cMethod='not-a-real-method')
+    _send_job(in_q, data=None, cMethod='sep')
 
     result = out_q.get(timeout=10)
 
@@ -58,15 +60,14 @@ def test_worker_returns_none_when_measure_raises(worker):
 
 def test_worker_survives_exception_and_serves_next_job(worker):
     """A single bad job must not poison the worker. The next job must still
-    get a response (here, also None because we again pass a bad cMethod —
-    we just need to confirm the worker is still consuming and producing)."""
+    get a response."""
     in_q, out_q, p = worker
 
-    _send_job(in_q, cMethod='not-a-real-method')
+    _send_job(in_q, data=None, cMethod='sep')
     assert out_q.get(timeout=10) is None
     assert p.is_alive(), "worker died after first exception"
 
-    _send_job(in_q, cMethod='not-a-real-method')
+    _send_job(in_q, data=None, cMethod='sep')
     assert out_q.get(timeout=10) is None
     assert p.is_alive(), "worker died after second exception"
 

--- a/tests/test_photometry_worker.py
+++ b/tests/test_photometry_worker.py
@@ -127,6 +127,9 @@ def _minimal_cParms() -> dict:
         "ellip": 0.5,
         "nmin": 5,
         "expTime": 5.0,
+        "halfBoxX": 5,
+        "halfBoxY": 5,
+        "boxSize": 20,
     }
 
 

--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -1,8 +1,0 @@
-install()
-{
-    if test -z "$SCONSUTILS_DIR"; then
-        echo disabling scons because we do not support it.
-        mv SConstruct SConstruct-disabled
-    fi
-    default_install "$@"
-}


### PR DESCRIPTION
# Walkthrough — Refactoring Cleanup

## Changes Made

### agccActor

#### [centroid.py](file:///Users/wilfredo/Projects/Subaru/PFS/ICS/ics_agccActor/python/agccActor/centroid.py)

- **Region coordinates loop**: Defined a list of tuples `half_regions` with slices for both halves of the detector and processed them in a single `for` loop to extract spots and backgrounds.
- **Dynamic slice assignment**: Populated the `result` structured array via dynamic slicing with `start_idx` and `end_idx` inside the loop, avoiding hardcoded `0:nSpots1` and `nSpots1:nElem` indices.
- **Saturation array concatenation**: Simplified the initialization of the `satValue` array using `np.concatenate` and `np.repeat`.
- **Background subtraction loop**: Rewrote the background subtraction of `tempData` using a loop over `half_regions` and the extracted backgrounds.
- **In-place moment update**: Modified the iteratively-weighted FWHM updates to edit `result` in place if the moment converged (`conv == 0`), eliminating the need for temporary list allocations (`m20`, `m02`, `m11`, `flags`).
- **Semantic flags check**: Changed the bitmask logic from `result["flags"][i] & 1` to `result["flags"][i] & SourceDetectionFlag.RIGHT` for clarity.
- **Informative INFO level logging**: Added helpful `logger.info` statements at the beginning of the centroiding process (indicating the camera, threshold, and min area), per-region spot detection counts including background median and standard deviation, overall spot detection counts, and the number of spots failing FWHM moment convergence.

#### [AgccCmd.py](file:///Users/wilfredo/Projects/Subaru/PFS/ICS/ics_agccActor/python/agccActor/Commands/AgccCmd.py)

- **Helper method `parseCameras`**: Created a centralized helper method to parse the optional `cameras` command keyword. It returns a list of 0-indexed camera indices or defaults to either the running cameras (if `defaultToRunning=True` is passed) or all cameras.
- **Handler Refactoring**: Cleaned up the duplicate parsing logic in 8 command handlers (`shutterOps`, `expose`, `abort`, `setframe`, `resetframe`, `setmode`, `getmode`, and `settemperature`) to use `parseCameras`, removing all redundant `if cams is None` check blocks.
- **Cleaned Unused Variables**: Removed `cmdKeys` variable assignments that became unused after refactoring.